### PR TITLE
Updates to work with Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ On your Raspberry Pi, open a terminal and enter the following:
 
 ```
 sudo -s
-echo "deb http://apt.adafruit.com/raspbian/ wheezy main" >> /etc/apt/sources.list
+echo "deb http://apt.adafruit.com/raspbian/ jessie main" >> /etc/apt/sources.list
 wget -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
 apt-get update
+apt install node
+apt-get autoremove
 apt-get install occidentalis
 ```
 


### PR DESCRIPTION
These changes are what worked for me with Raspbian Jessie which is the current stable version of Debian so more likely to be used from now on than the wheezy-specific stuff that is there.
